### PR TITLE
New sub-package: auto

### DIFF
--- a/Overview.md
+++ b/Overview.md
@@ -10,8 +10,11 @@ A `Table` is an interface.  There is one core public type which implements the
 interface.  This allows the core type to be embedded in the wrapper/display
 objects and for those to satisfy the table interface, thus being tables
 themselves.  Rows and cells are not interfaces.  The core public type for a
-table is, imaginatively, `*ATable`.  Callers are advised to use the `Table`
-interface, if they need to care about a non-inferred type.
+table is, imaginatively, `*ATable`.
+
+Callers doing simple table usage should import the `auto` sub-package and use
+the `RenderTable` interface type, or use tabular's code `Table` interface
+(which is part of `RenderTable`).
 
 A table consists of rows of cells and some metadata.  The metadata includes
 virtual columns, allowing for addressing by column too.  Columns are
@@ -100,6 +103,38 @@ in your wrapper object.  If you want dynamic attributes, updated based upon
 content, _then_ use properties, and consider how to hide this from your users.
 
 
+Auto
+----
+
+This is the `auto` sub-package of `tabular`.
+
+This provides a `RenderTable` interface, which adds `Render()` and
+`RenderTo()` methods to the core `tabular.Table`.
+
+Unlike the more-specific sub-packages, the `New()` and `Wrap()` methods take a
+string argument.  The string is a style.  This string is taken to be a
+dot-joined sequence of sections, where the first section is a sub-package or a
+`texttable/decoration.Decoration`.
+
+So `auto.New("csv")` returns an `auto.RenderTable` which is satisfied by a
+`*csv.CSVTable`.  `auto.New("texttable.utf8-light")` is equivalent to
+`auto.New("utf8-light")` and returns an `auto.RenderTable` which is satisfied
+by a `*texttable.TextTable` with the decoration set to `utf8-light`.
+
+`auto.New("csv.foo")` is currently equivalent to `auto.New("csv")` but future
+extensions might pass the `foo` onto some appropriate initialization of the
+`csv` package.
+
+The `auto` sub-package does not provide specific implementations of the
+`Render` or `RenderTo` sub-packages, but does provide the usual package-level
+wrappers.
+
+In addition, `auto.ListStyles()` returns a sorted list of strings, each of
+which is a valid input for `auto.New(style)`.  The list is not guaranteed to
+be exhaustive, but should cover the common cases.  It is guaranteed to be
+exhaustive of all top-level style names (the bit before the first `.`).
+
+
 Text Table Display
 ------------------
 
@@ -174,3 +209,20 @@ _current_ style, but we should accept PRs for any sane options, and also
 `fieldSeparator` is called out in the struct, and there are no mutators for
 it.  That's not a bug, just "not yet implemented, waiting for solid
 use-cases".
+
+
+Coding Style
+------------
+
+1. All code should pass `go fmt` and `go vet`
+2. `golint` is too opinionated in ways I care about and is explicitly not a
+   fixed goal.  Reducing its complaints for new code is worthwhile, unless
+   that contradicts something here.  Changing an API to match it's style is
+   never acceptable, unless there's an API major revision bump.
+3. Exported constants should be `ALL_CAPS`
+4. Imports should be in batched groups, so that `go fmt` will sort within each
+   group but not move between groups; those groups should be:
+  1. stdlib packages
+  2. testing-related packages, if we're a test
+  3. intra-repo/org packages
+  4. external third-party packages

--- a/auto/auto.go
+++ b/auto/auto.go
@@ -1,0 +1,89 @@
+// Copyright © 2016 Pennock Tech, LLC.
+// All rights reserved, except as granted under license.
+// Licensed per file LICENSE.txt
+
+package auto
+
+import (
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/PennockTech/tabular"
+	"github.com/PennockTech/tabular/csv"
+	"github.com/PennockTech/tabular/html"
+	"github.com/PennockTech/tabular/texttable"
+	"github.com/PennockTech/tabular/texttable/decoration"
+)
+
+// Any table sub-package which can be rendered should meet this
+// interface.
+type RenderTable interface {
+	tabular.Table
+	Render() (string, error)
+	RenderTo(io.Writer) error
+}
+
+// Wrap takes a tabular.Table and a style string.  While Wrap returns
+// the RenderTable interface, the type underlying that interface is
+// dependent upon the contents of the style string.
+//
+// The style is a dot (period) separated sequence of fields, but will usually
+// just be a single field with no dot.  The first section is either the name of
+// a sub-package, or a known registered decoration of texttable.
+// Wrap(t, "texttable.utf8-light") is the same as Wrap(t, "utf8-light").
+//
+// The style sections after the first are interpreted dependent upon the first
+// section and not yet locked down by API.
+func Wrap(t tabular.Table, style string) RenderTable {
+	sections := strings.Split(style, ".")
+	switch strings.ToLower(sections[0]) {
+	case "csv":
+		return csv.Wrap(t)
+	case "html":
+		// TODO: do we want to take `html.caption="foo.bar".class="a b c".whatever ?
+		return html.Wrap(t)
+	case "texttable":
+		tt := texttable.Wrap(t)
+		if len(sections) > 1 {
+			tt.SetDecorationNamed(sections[1])
+		}
+		return tt
+	default:
+		tt := texttable.Wrap(t)
+		tt.SetDecorationNamed(sections[0])
+		return tt
+	}
+}
+
+// New creates a new tabular.Table and Wrap()s it.
+func New(style string) RenderTable {
+	return Wrap(tabular.New(), style)
+}
+
+// ListStyles returns a sorted list of strings, where each string is a valid
+// input to the New function.  The list is not exhaustive, sub-styles may be
+// either included or omitted; the results should be sufficiently
+// representative to be used by help systems for listing available styles,
+// without having to go into every possible mutation.
+func ListStyles() []string {
+	l := decoration.RegisteredDecorationNames()
+	l = append(l, "csv", "html")
+	sort.Strings(l)
+	return l
+}
+
+// Render takes a tabular.Table and a style and creates a default-options
+// object of the type indicated by the style, with any tuning options from that
+// style applied, and then calls the Render method upon it.
+func Render(t tabular.Table, style string) (string, error) {
+	return Wrap(t, style).Render()
+}
+
+// RenderTo takes a tabular.Table and a style and creates a default-options
+// object of the type indicated by the style, with any tuning options from that
+// style applied, and then calls the RenderTo method upon it.  API considers
+// the style to be a decoration/refinement and places that parameter last.
+func RenderTo(t tabular.Table, w io.Writer, style string) error {
+	return Wrap(t, style).RenderTo(w)
+}

--- a/auto/table_test.go
+++ b/auto/table_test.go
@@ -1,0 +1,119 @@
+// Copyright © 2016 Pennock Tech, LLC.
+// All rights reserved, except as granted under license.
+// Licensed per file LICENSE.txt
+
+package auto_test
+
+import (
+	"bytes"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/liquidgecka/testlib"
+
+	"github.com/PennockTech/tabular"
+	"github.com/PennockTech/tabular/auto"
+	"github.com/PennockTech/tabular/csv"
+	"github.com/PennockTech/tabular/html"
+	"github.com/PennockTech/tabular/texttable"
+)
+
+func populate(T *testlib.T, tb tabular.Table) {
+	tb.AddHeaders("foo", "loquacious", "x")
+	tb.AddRowItems(42, ".", "fred")
+	tb.AddRowItems("snerty", "word", "r")
+	tb.AddSeparator()
+	tb.AddRowItems(" ", true, nil)
+	T.Equal(tb.Errors(), nil, "no errors just adding items")
+}
+
+func TestNewBasic(t *testing.T) {
+	T := testlib.NewT(t)
+	defer T.Finish()
+
+	bare := tabular.New()
+
+	tac := auto.New("csv")
+	tdc := csv.New()
+
+	tah := auto.New("html")
+	tdh := html.New()
+
+	tat := auto.New("texttable")
+	tdt := texttable.New()
+
+	taa1 := auto.New("ascii-simple")
+	taa2 := auto.New("texttable.ascii-simple")
+	tda := texttable.New()
+	tda.SetDecorationNamed("ascii-simple")
+
+	for _, tb := range []tabular.Table{
+		bare, tac, tdc, tah, tdh, tat, tdt, taa1, taa2, tda,
+	} {
+		populate(T, tb)
+	}
+
+	// This also serves to confirm that the tables created directly satisfy our interface.
+	for i, tuple := range []struct {
+		a, b  auto.RenderTable
+		style string
+	}{
+		{tac, tdc, "csv"},
+		{tah, tdh, "html"},
+		{tat, tdt, "texttable"},
+		{taa1, tda, "ascii-simple"},
+		{taa2, tda, "texttable.ascii-simple"},
+		{taa1, taa2, "texttable.ascii-simple"},
+	} {
+		typeA := reflect.TypeOf(tuple.a).String()
+		typeB := reflect.TypeOf(tuple.b).String()
+		T.Equalf(typeA, typeB, "auto [%d] tuple's pairs of identical type", i)
+
+		ra, err := tuple.a.Render()
+		T.ExpectSuccessf(err, "auto [%d] tuple.a rendered without error", i)
+
+		bufB := &bytes.Buffer{}
+		err = tuple.b.RenderTo(bufB)
+		T.ExpectSuccessf(err, "auto [%d] tuple.b rendered without error", i)
+
+		T.Equalf(ra, bufB.String(), "auto [%d] tuple renders identically", i)
+
+		if _, ok := tuple.b.(auto.RenderTable); !ok {
+			T.Fatalf("auto [%d] tuple.b does not satisfy RenderTable interface", i)
+		}
+
+		wrapped := auto.Wrap(bare, tuple.style)
+		typeW := reflect.TypeOf(wrapped).String()
+		T.Equalf(typeW, typeB, "auto [%d] wrapping of bare to %q of identical type", i, tuple.style)
+		bufW := &bytes.Buffer{}
+		err = wrapped.RenderTo(bufW)
+		T.ExpectSuccessf(err, "auto [%d] bare-wrapped %q rendered without error", i, tuple.style)
+
+		T.Equalf(ra, bufW.String(), "auto [%d] bare-wrapped %q rendered identically", i, tuple.style)
+	}
+}
+
+func TestListStyles(t *testing.T) {
+	T := testlib.NewT(t)
+	defer T.Finish()
+
+	available := auto.ListStyles()
+	if !sort.StringsAreSorted(available) {
+		T.Error("ListStyles() strings not sorted")
+	}
+
+	have := make(map[string]struct{}, len(available))
+	for _, h := range available {
+		if _, already := have[h]; already {
+			T.Errorf("ListStyles() duplicated result: %q", h)
+		}
+		have[h] = struct{}{}
+	}
+
+	for _, expect := range []string{"csv", "html", "ascii-simple", "utf8-light"} {
+		if _, ok := have[expect]; !ok {
+			T.Errorf("ListStyles() missing expected value %q", expect)
+		}
+	}
+}


### PR DESCRIPTION
The `auto` sub-package should probably be the main package used as an
interface by regular table users who want to pass through to an end-user
a choice of table type.  It lets you create a generic `tabular.Table`
interface-type-wrapped only far enough to additionally require `Render`
and `RenderTo` methods; the style is a string, with content constraints.
The reified type depends upon the style.

`auto.ListStyles()` returns a list of candidate styles suitable for use,
geared for use in construct help-messages for options.

See imminent github.com/philpennock/character feature exposing this.