### PR TITLE
Implement markdown support

### DIFF
--- a/Overview.md
+++ b/Overview.md
@@ -211,6 +211,28 @@ it.  That's not a bug, just "not yet implemented, waiting for solid
 use-cases".
 
 
+Markdown Rendering
+------------------
+
+This is the `markdown` sub-package of `tabular`.
+
+The dialect emitted is "GitHub Flavored Markdown" tables.
+
+For automated production you should avoid this renderer in favor of the `html`
+renderer; the markdown table support is extremely limited and there is no
+definition of what should happen for a number of otherwise valid inputs.
+
+The expectation is that documentation maintainers can use this package with
+their client tool to get output which can be inserted in markdown and be
+subject to human review.  If you don't have a human in the loop, then there's
+absolutely no reason to not just use the HTML renderer: Markdown passes
+through HTML, so the HTML output is more portable and safer.
+
+But if your client tooling supports `auto` and can just be asked "hey, give me
+the markdown" then documentation maintainers can use that for grabbing
+samples.
+
+
 Coding Style
 ------------
 

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -1,0 +1,228 @@
+// Copyright © 2016 Pennock Tech, LLC.
+// All rights reserved, except as granted under license.
+// Licensed per file LICENSE.txt
+
+/*
+Markdown core does not support tables; for the most portable support,
+assuming HTML is the final target, use the `html` sub-package instead.
+
+Support for GitHub-Flavored Markdown's Tables is fairly widespread in
+markdown packages.  That's the dialect which we speak at this time.
+
+Note that the data model supported by GFM tables is very limited and is
+likely to break on a number of valid inputs.  We attempt to deal
+"safely" with this, to meet the security model, but it's likely that
+there are inputs which break the integrity of the markdown table for
+various renderers.  Again, the solution is to use the HTMLTable wrapper
+instead.
+
+So why have this sub-package?  In my experience, people working on
+documentation like to be able to use the same input data and ask the
+tools to generate markdown, which can then be included as-is, for output
+in various formats.  Thus we have _two_ target audiences: a human reviewing
+our output as it goes into .md documents, and people viewing the rendered
+tables later.  We need to look "decent" for both, but can defer sanitization
+to the human review step.
+*/
+package markdown
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"io"
+	"strings"
+
+	"github.com/PennockTech/tabular"
+	"github.com/PennockTech/tabular/length"
+)
+
+// A MarkdownTable wraps a tabular.Table to act as a render control for Markdown output.
+type MarkdownTable struct {
+	tabular.Table
+}
+
+// Wrap returns a MarkdownTable rendering object for the given tabular.Table.
+func Wrap(t tabular.Table) *MarkdownTable {
+	var ws widthSetter
+	t.RegisterPropertyCallback(t, tabular.CB_AT_RENDER, tabular.CB_ON_CELL, ws)
+	return &MarkdownTable{
+		Table: t,
+	}
+}
+
+// New returns a MarkdownTable with a new Table inside it, access via .Table
+// or just use the interface methods on the MarkdownTable.
+func New() *MarkdownTable {
+	return Wrap(tabular.New())
+}
+
+// Render takes a tabular.Table and creates a default options MarkdownTable object
+// and then calls the Render method upon it.
+func Render(t tabular.Table) (string, error) {
+	return Wrap(t).Render()
+}
+
+// RenderTo takes a tabular.Table and creates a default options MarkdownTable object
+// and calls the RenderTo method upon it.
+func RenderTo(t tabular.Table, w io.Writer) error {
+	return Wrap(t).RenderTo(w)
+}
+
+// Render takes a tabular Table and returns a string representing the fully
+// rendered table or an error.
+func (mt *MarkdownTable) Render() (string, error) {
+	b := &bytes.Buffer{}
+	err := mt.RenderTo(b)
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// RenderTo writes the table to the provided writer, stopping if it encounters
+// an error.
+func (mt *MarkdownTable) RenderTo(w io.Writer) error {
+	mt.InvokeRenderCallbacks()
+	var err error
+	columnCount := mt.NColumns()
+	if columnCount < 1 {
+		return fmt.Errorf("markdown:RenderTo: can't emit a table with %d columns", columnCount)
+	}
+
+	// We have headers, then a control line which affects alignment, then the body.
+	// No titles, that's not currently in the core tabular model.
+	// We do want to try to align columns, for prettyness in markdown to be edited
+	// by humans, but are willing to give up on alignment in degenerate cases (embedded newlines).
+
+	headers := mt.Headers()
+	if headers == nil {
+		return fmt.Errorf("markdown:RenderTo: can't emit a table without headers")
+	}
+
+	widths := make([]int, columnCount)
+	if len(headers) > columnCount {
+		return fmt.Errorf("structural bug, columnCount %d but %d headers", columnCount, len(headers))
+	}
+	for i := range headers {
+		widths[i] = CellPropertyExtractWidth(&headers[i])
+	}
+	for n, r := range mt.AllRows() {
+		if r.IsSeparator() {
+			continue
+		}
+		cells := r.Cells()
+		if len(cells) > columnCount {
+			return fmt.Errorf("structural bug, columnCount %d but %d cells in row %d", columnCount, len(cells), n)
+		}
+		for i := range cells {
+			w := CellPropertyExtractWidth(&cells[i])
+			if w > widths[i] {
+				widths[i] = w
+			}
+		}
+	}
+
+	if err = mt.emitRow(w, columnCount, headers, widths); err != nil {
+		return err
+	}
+
+	controlRowCells := make([]tabular.Cell, 0, columnCount)
+	for i := 0; i < columnCount; i++ {
+		width := widths[i]
+		// spec mandates at least three dashes
+		if width < 3 {
+			width = 3
+		}
+		// TODO: support column alignment
+		content := strings.Repeat("-", width)
+		controlRowCells = append(controlRowCells, tabular.NewCell(content))
+	}
+	if err = mt.emitRow(w, columnCount, controlRowCells, widths); err != nil {
+		return err
+	}
+
+	for _, r := range mt.AllRows() {
+		if r.IsSeparator() {
+			continue
+		}
+		if err = mt.emitRow(w, columnCount, r.Cells(), widths); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitRow handles just one row, whether from headers or body.
+// It needs to know how many columns should be in the row, so that it can add extras,
+// or error out, as needed.
+// Note that when we add alignment support, we'll need to handle colons inside
+// the column padding space.
+func (mt *MarkdownTable) emitRow(w io.Writer, columnCount int, cells []tabular.Cell, widths []int) error {
+	var i int
+	var max int = len(cells)
+	if columnCount < max {
+		return fmt.Errorf("structural bug, columnCount %d but %d cells", columnCount, max)
+	}
+	// Game-plan:
+	// 1. repeatedly print all-but-last available column with trailing separator
+	// 2. print last column, no separator
+	// 3. if too few columns in this row, repeatedly add leading separator and extra column
+	// if too many columns in this row, should have errored out above
+	// if only one column, the first repeated print should be skipped
+	//
+	// For alignment, note that escaping will completely throw things off.  That's okay.
+	// We don't align right for escaped content.  We're after "close enough to not be jarring".
+	fmt.Fprint(w, "| ")
+	for i = 0; i < max-1; i++ {
+		if _, err := fmt.Fprint(w, mt.mdPaddedCellEscape(cells, widths, i), " | "); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprint(w, mt.mdPaddedCellEscape(cells, widths, i), " |"); err != nil {
+		return err
+	}
+	i++
+	for ; i < columnCount; i++ {
+		if _, err := fmt.Fprint(w, " |"); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// mdPaddedCellEscape is a wrapper around mdCellEscape which takes care of padding, widths, etc
+// (and so needs more parameters)
+func (mt *MarkdownTable) mdPaddedCellEscape(cells []tabular.Cell, widths []int, i int) string {
+	baseline := mt.mdCellEscape(cells[i].String())
+	wantWidth := widths[i]
+	haveWidth := length.StringCells(baseline)
+	if haveWidth >= wantWidth {
+		return baseline
+	}
+	// TODO: handle alignment
+	return baseline + strings.Repeat(" ", wantWidth-haveWidth)
+}
+
+// mdCellEscape handles producing the output for one field, with surrounding
+// quotes.  Note that there are two separate issues here:
+// 1. Use of the pipe character as a column separator
+// 2. Use of HTML!  Our security model does not trust the content within the
+//    table, so we should escape everything.  If there's a use-case for more
+//    trusted content, that should be a non-default option which we can add
+//    later.
+//
+// What about use of other markdown?  For now, we're going with "anything
+// actively dangerous should require dropping to HTML to accomplish".  If I'm
+// wrong about this, please file a bug report!
+//
+// For multi-line content, our approach is to replace newlines with HTML escape
+// sequences.  Markdown tables do not support multiple "physical" lines in one
+// cell, so this seems the only way.  We ignore CR, only handling LF.
+// Really, at this point, we are past the limits of the spec.
+func (mt *MarkdownTable) mdCellEscape(in string) string {
+	return strings.Replace(strings.Replace(html.EscapeString(in), "|", "&#x7c;", -1), "\n", "&#x0a;", -1)
+}

--- a/markdown/properties.go
+++ b/markdown/properties.go
@@ -1,0 +1,56 @@
+// Copyright © 2016 Pennock Tech, LLC.
+// All rights reserved, except as granted under license.
+// Licensed per file LICENSE.txt
+
+package markdown
+
+import (
+	"errors"
+
+	"github.com/PennockTech/tabular"
+)
+
+type propertyKey struct {
+	name string
+}
+
+func (p *propertyKey) String() string { return "markdowntable property keyid " + p.name }
+
+var (
+	propWidth = &propertyKey{"width"}
+)
+
+type width struct {
+	cellWidth int
+}
+
+type widthSetter struct{}
+
+var ErrNotCellProperties = errors.New("markdowntable: width-set: not given a cell")
+
+func (_ widthSetter) UpdateProperties(po tabular.PropertyOwner) error {
+	cell, ok := po.(*tabular.Cell)
+	if !ok {
+		return ErrNotCellProperties
+	}
+
+	// TODO: move these calculations into separate common sub-package?
+	dims := width{
+		cellWidth: cell.TerminalCellWidth(),
+	}
+
+	po.SetProperty(propWidth, dims)
+	return nil
+}
+
+func CellPropertyExtractWidth(cell *tabular.Cell) int {
+	dimsI := cell.GetProperty(propWidth)
+	if dimsI == nil {
+		return 0
+	}
+	dims, ok := dimsI.(width)
+	if ok {
+		return dims.cellWidth
+	}
+	return 0
+}

--- a/markdown/table_test.go
+++ b/markdown/table_test.go
@@ -1,0 +1,169 @@
+// Copyright © 2016 Pennock Tech, LLC.
+// All rights reserved, except as granted under license.
+// Licensed per file LICENSE.txt
+
+package markdown_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/liquidgecka/testlib"
+
+	"github.com/PennockTech/tabular"
+	"github.com/PennockTech/tabular/markdown"
+)
+
+func testViaCreatorFunc(t *testing.T, creator func() tabular.Table) {
+	T := testlib.NewT(t)
+	defer T.Finish()
+
+	tb := creator()
+	T.NotEqual(tb, nil, "have a table")
+
+	have, err := markdown.Render(tb)
+	T.Equal(tb.Errors(), nil, "no errors stored when rendering empty table via pkg func")
+	T.ExpectError(err, "should have failed to render the table while empty")
+
+	tb.AddHeaders("foo", "loquacious", "x")
+	tb.AddRowItems(42, ".", "fred")
+	tb.AddRowItems("snerty", "word", "r")
+	tb.AddSeparator()
+	tb.AddRowItems(" ", true, nil)
+	T.Equal(tb.Errors(), nil, "no errors just adding items")
+
+	should := `
+| foo    | loquacious | x    |
+| ------ | ---------- | ---- |
+| 42     | .          | fred |
+| snerty | word       | r    |
+|        | true       |      |
+`
+	should = strings.TrimLeftFunc(should, unicode.IsSpace)
+
+	// When creator is creating a markdown.MarkdownTable, this will double-wrap, but
+	// should still work (same as we should be able to wrap tabular.Table
+	// inside csv.CSVTable inside markdown.MarkdownTable)
+	have, err = markdown.Render(tb)
+	T.ExpectSuccess(err, "no errors returned when rendering basic table via pkg func")
+	T.Equal(tb.Errors(), nil, "no errors stored when rendering basic table via pkg func")
+	T.Equal(have, should, "basic output emits cleanly via pkg func")
+
+	tb2 := creator()
+	T.NotEqual(tb2, nil, "have a table")
+	tb2.AddRowItems("42", "fred")
+	_, err = markdown.Render(tb2)
+	T.ExpectError(err, "headerless table should have failed to render")
+
+	tb.AddRowItems("a\nb\nc", `d"e`, 1)
+	should += strings.TrimLeftFunc(`
+| a&#x0a;b&#x0a;c | d&#34;e    | 1    |
+`, unicode.IsSpace)
+
+	have, err = markdown.Render(tb)
+	T.ExpectSuccess(err, "no errors returned when rendering multiline quote-containing table")
+	T.Equal(tb.Errors(), nil, "no errors stored when rendering multiline quote-containing table")
+	T.Equal(have, should, "multiline quote-containing output emits 'cleanly'")
+}
+
+func TestTableMarkdownOfTabular(t *testing.T) {
+	testViaCreatorFunc(t, func() tabular.Table { return tabular.New() })
+}
+
+func TestTableMarkdownDirectly(t *testing.T) {
+	testViaCreatorFunc(t, func() tabular.Table { return markdown.New() })
+}
+
+type brokenTable struct {
+	*tabular.ATable
+	overrideColumns int
+}
+
+func (b brokenTable) NColumns() int { return b.overrideColumns }
+
+func TestBrokenTables(t *testing.T) {
+	T := testlib.NewT(t)
+	defer T.Finish()
+
+	tb := tabular.New()
+	T.NotEqual(tb, nil, "have a table")
+
+	tb.AddRowItems("alpha", "beta", "gamma")
+	brokeTB := brokenTable{ATable: tb}
+	brokeTB.overrideColumns = 2
+	broken := markdown.Wrap(&brokeTB)
+
+	_, err := broken.Render()
+	T.ExpectError(err, "table should fail to render if too few columns for rows")
+
+	tb.AddHeaders("1", "2", "3", "4")
+	brokeTB.overrideColumns = 4
+	_, err = broken.Render()
+	T.ExpectSuccess(err, "table renders something when enough columns")
+	brokeTB.overrideColumns = 3
+	_, err = broken.Render()
+	T.ExpectError(err, "table should fail to render if too few columns for headers")
+}
+
+func TestFileWritingMarkdown(t *testing.T) {
+	T := testlib.NewT(t)
+	defer T.Finish()
+
+	tb := tabular.New()
+	T.NotEqual(tb, nil, "have a table")
+
+	should := []byte(`
+| foo    | loquacious | x    |
+| ------ | ---------- | ---- |
+| 42     | .          | fred |
+| snerty | word       | r    |
+|        | true       |      |
+`)
+	should = bytes.TrimLeftFunc(should, unicode.IsSpace)
+
+	tb.AddHeaders("foo", "loquacious", "x")
+	tb.AddRowItems(42, ".", "fred")
+	tb.AddRowItems("snerty", "word", "r")
+	tb.AddSeparator()
+	tb.AddRowItems(" ", true, nil)
+	T.Equal(tb.Errors(), nil, "no errors just adding items")
+
+	temp := T.TempFile()
+	err := markdown.RenderTo(tb, temp)
+	T.ExpectSuccess(err, "table renders to temporary file")
+
+	newOff, err := temp.Seek(0, 0)
+	T.ExpectSuccess(err, "seek-to-start of temp file succeeds")
+	T.Equal(newOff, int64(0), "offset after seeking to start is 0")
+
+	contents, err := ioutil.ReadAll(temp)
+	T.ExpectSuccess(err, "reading contents from temp file")
+	T.Equal(contents, should, "content in filesystem is as expected")
+}
+
+// degenerate case, no affixed separators
+func TestSingleColumnMarkdown(t *testing.T) {
+	T := testlib.NewT(t)
+	defer T.Finish()
+
+	tb := markdown.New()
+	T.NotEqual(tb, nil, "have a table")
+	should := `
+| header |
+| ------ |
+| line 1 |
+| two    |
+`
+	should = strings.TrimLeftFunc(should, unicode.IsSpace)
+
+	tb.AddHeaders("header")
+	tb.AddRowItems("line 1")
+	tb.AddRowItems("two")
+	T.Equal(tb.Errors(), nil, "no errors just adding items")
+	have, err := tb.Render()
+	T.ExpectSuccess(err, "single-column table renders without errors")
+	T.Equal(have, should, "got correct single-column output")
+}


### PR DESCRIPTION
There are two target audiences; see Overview.md for details.

I still recommend using HTML in preference, if markdown prettiness
doesn't matter.

Fixes #2 

@case FYI