### PR TITLE
Switch to go.pennock.tech/tabular for imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,19 @@ branches:
   except:
     - /^(?:exp|wip)(?:[/_-].*)?$/
 
+# This doesn't fully work; rsync's content into right place, but the trailing .git
+# on the remote repo URL confuses go get, thus the first steps of install
+go_import_path: go.pennock.tech/tabular
+
+# The "correct"ish way is:
+# rem="$(git remote)"; old_remote="$(git remote get-url "$rem")"; git remote set-url "$rem" "${old_remote%.git}"
+# but Travis's git doesn't recognize the `get-url` sub-command.
+# So we use `git config` instead.
+
 install:
+  - git --version
+  - old_remote="$(git config --get remote.origin.url)"; git config remote.origin.url "${old_remote%.git}"
+  - git config --get remote.origin.url
   - go get -t -v -u ./...
   - test "${UPLOAD_COVERAGE:-false}" != "true" || go get github.com/mattn/goveralls
 

--- a/CoverTest.sh
+++ b/CoverTest.sh
@@ -5,7 +5,7 @@
 # Based upon mmindenhall's solution in <https://github.com/golang/go/issues/6909>
 #
 
-TOP="github.com/PennockTech/tabular"
+TOP="go.pennock.tech/tabular"
 
 progname="$(basename "$0")"
 trace() { printf >&2 "%s: %s\n" "$progname" "$*" ; }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ tabular
 =======
 
 [![Continuous Integration](https://secure.travis-ci.org/PennockTech/tabular.svg?branch=master)](http://travis-ci.org/PennockTech/tabular)
-[![Documentation](https://godoc.org/github.com/PennockTech/tabular?status.png)](https://godoc.org/github.com/PennockTech/tabular)
+[![Documentation](https://godoc.org/go.pennock.tech/tabular?status.png)](https://godoc.org/go.pennock.tech/tabular)
 
 The `tabular` package provides a Golang library for storing data in a table
 consisting of rows and columns.  Sub-packages provide for rendering such a
@@ -22,6 +22,6 @@ directly.
 An overview guide to the codebase can be found in
 [the Overview.md](Overview.md)
 
-[The usage documentation is in Godoc format](https://godoc.org/github.com/PennockTech/tabular)
+[The usage documentation is in Godoc format](https://godoc.org/go.pennock.tech/tabular)
 
 This package should be installable in the usual `go get` manner.

--- a/atable.go
+++ b/atable.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 // An ATable is the top-level container for a grid in tabular.
 // You should not be declaring fields to be of type ATable; instead,

--- a/auto/auto.go
+++ b/auto/auto.go
@@ -2,19 +2,19 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package auto
+package auto // import "go.pennock.tech/tabular/auto"
 
 import (
 	"io"
 	"sort"
 	"strings"
 
-	"github.com/PennockTech/tabular"
-	"github.com/PennockTech/tabular/csv"
-	"github.com/PennockTech/tabular/html"
-	"github.com/PennockTech/tabular/markdown"
-	"github.com/PennockTech/tabular/texttable"
-	"github.com/PennockTech/tabular/texttable/decoration"
+	"go.pennock.tech/tabular"
+	"go.pennock.tech/tabular/csv"
+	"go.pennock.tech/tabular/html"
+	"go.pennock.tech/tabular/markdown"
+	"go.pennock.tech/tabular/texttable"
+	"go.pennock.tech/tabular/texttable/decoration"
 )
 
 // Any table sub-package which can be rendered should meet this

--- a/auto/table_test.go
+++ b/auto/table_test.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package auto_test
+package auto_test // import "go.pennock.tech/tabular/auto"
 
 import (
 	"bytes"
@@ -12,12 +12,12 @@ import (
 
 	"github.com/liquidgecka/testlib"
 
-	"github.com/PennockTech/tabular"
-	"github.com/PennockTech/tabular/auto"
-	"github.com/PennockTech/tabular/csv"
-	"github.com/PennockTech/tabular/html"
-	"github.com/PennockTech/tabular/markdown"
-	"github.com/PennockTech/tabular/texttable"
+	"go.pennock.tech/tabular"
+	"go.pennock.tech/tabular/auto"
+	"go.pennock.tech/tabular/csv"
+	"go.pennock.tech/tabular/html"
+	"go.pennock.tech/tabular/markdown"
+	"go.pennock.tech/tabular/texttable"
 )
 
 func populate(T *testlib.T, tb tabular.Table) {

--- a/cell.go
+++ b/cell.go
@@ -2,13 +2,13 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 import (
 	"fmt"
 	"strings"
 
-	"github.com/PennockTech/tabular/length"
+	"go.pennock.tech/tabular/length"
 )
 
 // A Cell is one item in a table; it holds an object and fields calculated

--- a/csv/csv.go
+++ b/csv/csv.go
@@ -2,14 +2,14 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package csv
+package csv // import "go.pennock.tech/tabular/csv"
 
 import (
 	"bytes"
 	"fmt"
 	"io"
 
-	"github.com/PennockTech/tabular"
+	"go.pennock.tech/tabular"
 )
 
 // A CSVTable wraps a tabular.Table to act as a render control for CSV output.

--- a/csv/table_test.go
+++ b/csv/table_test.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package csv_test
+package csv_test // import "go.pennock.tech/tabular/csv"
 
 import (
 	"io/ioutil"
@@ -10,8 +10,8 @@ import (
 
 	"github.com/liquidgecka/testlib"
 
-	"github.com/PennockTech/tabular"
-	"github.com/PennockTech/tabular/csv"
+	"go.pennock.tech/tabular"
+	"go.pennock.tech/tabular/csv"
 )
 
 func testViaCreatorFunc(t *testing.T, creator func() tabular.Table) {

--- a/doc.go
+++ b/doc.go
@@ -51,4 +51,4 @@ applied to cells, but some are applied to larger objects.  The registration need
 to know what object is to hold the callback, which target the callback is to be
 applied to, when it should be invoked, and the new callback being registered.
 */
-package tabular
+package tabular // import "go.pennock.tech/tabular"

--- a/error_containers.go
+++ b/error_containers.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 // ErrorContainer holds a list of errors.
 // The tabular package uses a batched error model, where errors accumulate

--- a/error_types.go
+++ b/error_types.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 import (
 	"fmt"

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular_test
+package tabular_test // import "go.pennock.tech/tabular"
 
 import (
 	"strings"
@@ -10,7 +10,7 @@ import (
 
 	"github.com/liquidgecka/testlib"
 
-	"github.com/PennockTech/tabular"
+	"go.pennock.tech/tabular"
 )
 
 func TestErrorNoSuchCell(t *testing.T) {

--- a/html/html.go
+++ b/html/html.go
@@ -9,14 +9,14 @@ Where texttable used properties on the table to control rendering, HTMLTable
 uses a wrapper object which methods can be set upon.
 I want to see which approach is "better".
 */
-package html
+package html // import "go.pennock.tech/tabular/html"
 
 import (
 	"bytes"
 	"html/template"
 	"io"
 
-	"github.com/PennockTech/tabular"
+	"go.pennock.tech/tabular"
 )
 
 // HTMLTable wraps a tabular Table to provide some extra information used

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package html_test
+package html_test // import "go.pennock.tech/tabular/html"
 
 import (
 	"fmt"
@@ -12,8 +12,8 @@ import (
 
 	"github.com/liquidgecka/testlib"
 
-	"github.com/PennockTech/tabular"
-	"github.com/PennockTech/tabular/html"
+	"go.pennock.tech/tabular"
+	"go.pennock.tech/tabular/html"
 )
 
 func TestHTMLTableRendering(t *testing.T) {

--- a/length/length.go
+++ b/length/length.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package length
+package length // import "go.pennock.tech/tabular/length"
 
 import (
 	"strings"

--- a/length/length_test.go
+++ b/length/length_test.go
@@ -2,14 +2,14 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package length_test
+package length_test // import "go.pennock.tech/tabular/length"
 
 import (
 	"testing"
 
 	"github.com/liquidgecka/testlib"
 
-	"github.com/PennockTech/tabular/length"
+	"go.pennock.tech/tabular/length"
 )
 
 func TestStringLengths(t *testing.T) {

--- a/location.go
+++ b/location.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 // We measure from 1:1 so that 0:0 means "not initialized" and if either x or y
 // is zero in a cell, we know the data is invalid.  For some contexts, one or

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -24,7 +24,7 @@ our output as it goes into .md documents, and people viewing the rendered
 tables later.  We need to look "decent" for both, but can defer sanitization
 to the human review step.
 */
-package markdown
+package markdown // import "go.pennock.tech/tabular/markdown"
 
 import (
 	"bytes"
@@ -33,8 +33,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/PennockTech/tabular"
-	"github.com/PennockTech/tabular/length"
+	"go.pennock.tech/tabular"
+	"go.pennock.tech/tabular/length"
 )
 
 // A MarkdownTable wraps a tabular.Table to act as a render control for Markdown output.

--- a/markdown/properties.go
+++ b/markdown/properties.go
@@ -2,12 +2,12 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package markdown
+package markdown // import "go.pennock.tech/tabular/markdown"
 
 import (
 	"errors"
 
-	"github.com/PennockTech/tabular"
+	"go.pennock.tech/tabular"
 )
 
 type propertyKey struct {

--- a/markdown/table_test.go
+++ b/markdown/table_test.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package markdown_test
+package markdown_test // import "go.pennock.tech/tabular/markdown"
 
 import (
 	"bytes"
@@ -13,8 +13,8 @@ import (
 
 	"github.com/liquidgecka/testlib"
 
-	"github.com/PennockTech/tabular"
-	"github.com/PennockTech/tabular/markdown"
+	"go.pennock.tech/tabular"
+	"go.pennock.tech/tabular/markdown"
 )
 
 func testViaCreatorFunc(t *testing.T, creator func() tabular.Table) {

--- a/pretty.go
+++ b/pretty.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 import (
 	"bytes"

--- a/properties.go
+++ b/properties.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 import (
 	"fmt"

--- a/render_callbacks.go
+++ b/render_callbacks.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 // InvokeRenderCallbacks is used by rendering packages to trigger a table-wide
 // invocation of render-time callbacks.

--- a/row.go
+++ b/row.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 import (
 	"errors"

--- a/table.go
+++ b/table.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 // The Table interface is a thin wrapper around the actual *ATable struct, so that
 // methods can all be on the interface and objects which embed an unnamed table

--- a/texttable/decoration/box_drawing.go
+++ b/texttable/decoration/box_drawing.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package decoration
+package decoration // import "go.pennock.tech/tabular/texttable/decoration"
 
 import (
 	"reflect"

--- a/texttable/decoration/emit.go
+++ b/texttable/decoration/emit.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package decoration
+package decoration // import "go.pennock.tech/tabular/texttable/decoration"
 
 import "strings"
 

--- a/texttable/decoration/registry.go
+++ b/texttable/decoration/registry.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package decoration
+package decoration // import "go.pennock.tech/tabular/texttable/decoration"
 
 import (
 	"sort"

--- a/texttable/decoration/registry_test.go
+++ b/texttable/decoration/registry_test.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package decoration
+package decoration // import "go.pennock.tech/tabular/texttable/decoration"
 
 import (
 	"testing"

--- a/texttable/decoration/strings.go
+++ b/texttable/decoration/strings.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package decoration
+package decoration // import "go.pennock.tech/tabular/texttable/decoration"
 
 import "strings"
 

--- a/texttable/decoration/strings_test.go
+++ b/texttable/decoration/strings_test.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package decoration
+package decoration // import "go.pennock.tech/tabular/texttable/decoration"
 
 import (
 	"testing"

--- a/texttable/decoration/styles.go
+++ b/texttable/decoration/styles.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package decoration
+package decoration // import "go.pennock.tech/tabular/texttable/decoration"
 
 // The const-style names provide for language error-checking for those who
 // explicitly import this package.  Both this and just passing a string

--- a/texttable/properties.go
+++ b/texttable/properties.go
@@ -2,14 +2,14 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package texttable
+package texttable // import "go.pennock.tech/tabular/texttable"
 
 import (
 	"errors"
 
-	"github.com/PennockTech/tabular"
-	"github.com/PennockTech/tabular/length"
-	"github.com/PennockTech/tabular/texttable/decoration"
+	"go.pennock.tech/tabular"
+	"go.pennock.tech/tabular/length"
+	"go.pennock.tech/tabular/texttable/decoration"
 )
 
 type propertyKey struct {

--- a/texttable/render.go
+++ b/texttable/render.go
@@ -2,15 +2,15 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package texttable
+package texttable // import "go.pennock.tech/tabular/texttable"
 
 import (
 	"bytes"
 	"errors"
 	"io"
 
-	"github.com/PennockTech/tabular"
-	"github.com/PennockTech/tabular/texttable/decoration"
+	"go.pennock.tech/tabular"
+	"go.pennock.tech/tabular/texttable/decoration"
 )
 
 // Render takes a tabular.Table and creates a default options TextTable object

--- a/texttable/style.go
+++ b/texttable/style.go
@@ -2,12 +2,12 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package texttable
+package texttable // import "go.pennock.tech/tabular/texttable"
 
 import (
 	"fmt"
 
-	"github.com/PennockTech/tabular/texttable/decoration"
+	"go.pennock.tech/tabular/texttable/decoration"
 )
 
 // SetDecoration sets a Decoration type for rendering a table.  The caller

--- a/texttable/table_test.go
+++ b/texttable/table_test.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package texttable_test
+package texttable_test // import "go.pennock.tech/tabular/texttable"
 
 import (
 	"io/ioutil"
@@ -10,12 +10,12 @@ import (
 
 	"github.com/liquidgecka/testlib"
 
-	"github.com/PennockTech/tabular/texttable"
+	"go.pennock.tech/tabular/texttable"
 
 	// for getting the CellLocation type
-	"github.com/PennockTech/tabular"
+	"go.pennock.tech/tabular"
 	// for testing via the named constants & functions
-	"github.com/PennockTech/tabular/texttable/decoration"
+	"go.pennock.tech/tabular/texttable/decoration"
 )
 
 type str struct {

--- a/texttable/wrap.go
+++ b/texttable/wrap.go
@@ -2,11 +2,11 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package texttable
+package texttable // import "go.pennock.tech/tabular/texttable"
 
 import (
-	"github.com/PennockTech/tabular"
-	"github.com/PennockTech/tabular/texttable/decoration"
+	"go.pennock.tech/tabular"
+	"go.pennock.tech/tabular/texttable/decoration"
 )
 
 // A TextTable wraps a tabular.Table to act as the render control for

--- a/types.go
+++ b/types.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 // Open questions:
 // * should we use interfaces to handle reflow and default to reflow

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@
 // All rights reserved, except as granted under license.
 // Licensed per file LICENSE.txt
 
-package tabular
+package tabular // import "go.pennock.tech/tabular"
 
 // We are a library, not a top-level binary, so we can't depend upon any
 // particular top-level linker action specifying versions.  That said, we


### PR DESCRIPTION
* Add package comments specifying the new canonical import path
* Add Travis `go_import_path`
  + work around Travis go_import_path being insufficient for Go tooling
    - Travis rsyncs content without changing remote's URL; they use the
      .git extension on GitHub, which Golang's `go get` is unhappy with.
    - direct `git config` hackery because old git install on Travis
      doesn't like the `git config get-url` approach.

Tests passing green.